### PR TITLE
Compare stack names in case insensitive manner

### DIFF
--- a/rancher/context.go
+++ b/rancher/context.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -102,7 +103,7 @@ func (c *Context) loadEnv() error {
 	}
 
 	for _, env := range envs.Data {
-		if c.ProjectName == env.Name {
+		if strings.EqualFold(c.ProjectName, env.Name) {
 			logrus.Debugf("Found environment: %s(%s)", env.Name, env.Id)
 			c.Environment = &env
 			return nil

--- a/tests/integration/cattletest/core/test_compose.py
+++ b/tests/integration/cattletest/core/test_compose.py
@@ -1147,3 +1147,20 @@ def _get_service(services, name):
 
     assert service is not None
     return service
+
+
+def test_stack_case(client, compose):
+    template = '''
+    web:
+        image: nginx
+    '''
+
+    project_name = create_project(compose, input=template)
+    find_one(client.list_environment, name=project_name)
+
+    compose.check_call(template, '--verbose', '-f', '-', '-p', project_name,
+                       'up', '-d')
+
+    compose.check_call(template, '--verbose', '-f', '-', '-p',
+                       project_name.upper(), 'up', '-d')
+    find_one(client.list_environment, name=project_name)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/1684

The correct way to test it would be: 

1) Create stack with camel cased name via Cattle
2) Try to access this environment using rancher-compose. As it lowercases the stack name to the call, the comparison with the name set in cattle, should be done in case insensitive manner.

I've added python test, but don't think it would exercise the use case correctly as compose would always lower case the name you pass in.