### PR TITLE
New flag on upgrade function to clean up previous service definition when set.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -55,7 +55,7 @@ func UpgradeCommand(factory app.ProjectFactory) cli.Command {
 				Usage: "Wait for upgrade to complete",
 			},
 			cli.BoolFlag{
-				Name:  "clean, c",
+				Name:  "cleanup, c",
 				Usage: "Remove the original service definition once upgraded, implies --wait",
 			},
 		},
@@ -74,7 +74,7 @@ func Upgrade(p *project.Project, c *cli.Context) {
 		FinalScale:     c.Int("scale"),
 		UpdateLinks:    c.Bool("update-links"),
 		Wait:           c.Bool("wait"),
-		Clean:          c.Bool("clean"),
+		CleanUp:        c.Bool("cleanup"),
 	})
 
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -56,7 +56,7 @@ func UpgradeCommand(factory app.ProjectFactory) cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  "clean, c",
-				Usage: "Remove the original service definition once upgraded",
+				Usage: "Remove the original service definition once upgraded, implies --wait",
 			},
 		},
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -55,7 +55,7 @@ func UpgradeCommand(factory app.ProjectFactory) cli.Command {
 				Usage: "Wait for upgrade to complete",
 			},
 			cli.BoolFlag{
-				Name: "clean, c",
+				Name:  "clean, c",
 				Usage: "Remove the original service definition once upgraded",
 			},
 		},
@@ -74,7 +74,7 @@ func Upgrade(p *project.Project, c *cli.Context) {
 		FinalScale:     c.Int("scale"),
 		UpdateLinks:    c.Bool("update-links"),
 		Wait:           c.Bool("wait"),
-		Clean:		c.Bool("clean"),
+		Clean:          c.Bool("clean"),
 	})
 
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -54,6 +54,10 @@ func UpgradeCommand(factory app.ProjectFactory) cli.Command {
 				Name:  "wait,w",
 				Usage: "Wait for upgrade to complete",
 			},
+			cli.BoolFlag{
+				Name: "clean, c",
+				Usage: "Remove the original service definition once upgraded",
+			},
 		},
 	}
 }
@@ -70,6 +74,7 @@ func Upgrade(p *project.Project, c *cli.Context) {
 		FinalScale:     c.Int("scale"),
 		UpdateLinks:    c.Bool("update-links"),
 		Wait:           c.Bool("wait"),
+		Clean:		c.Bool("clean"),
 	})
 
 	if err != nil {

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -15,6 +15,7 @@ type UpgradeOpts struct {
 	FinalScale     int
 	UpdateLinks    bool
 	Wait           bool
+	Clean	       bool
 }
 
 func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
@@ -93,6 +94,10 @@ func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
 
 	if opts.Wait {
 		return rFromService.Wait(service)
+	}
+
+	if opts.Clean {
+		return rFromService.Delete(service)
 	}
 
 	return nil

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -15,7 +15,7 @@ type UpgradeOpts struct {
 	FinalScale     int
 	UpdateLinks    bool
 	Wait           bool
-	Clean          bool
+	CleanUp        bool
 }
 
 func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
@@ -92,16 +92,14 @@ func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
 		return err
 	}
 
-	if opts.Wait || opts.Clean {
-		err := rFromService.Wait(service)
-		if err != nil {
+	if opts.Wait || opts.CleanUp {
+		if err := rFromService.Wait(service); err != nil {
 			return err
 		}
 	}
 
-	if opts.Clean {
-		err := rFromService.Delete()
-		if err != nil {
+	if opts.CleanUp {
+		if err := rFromService.Delete(); err != nil {
 			return err
 		}
 	}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -92,7 +92,7 @@ func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
 		return err
 	}
 
-	if opts.Wait {
+	if opts.Wait || opts.Clean {
 		err := rFromService.Wait(service)
 		if err != nil {
 			return err

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -15,7 +15,7 @@ type UpgradeOpts struct {
 	FinalScale     int
 	UpdateLinks    bool
 	Wait           bool
-	Clean	       bool
+	Clean          bool
 }
 
 func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -93,11 +93,17 @@ func Upgrade(p *project.Project, from, to string, opts UpgradeOpts) error {
 	}
 
 	if opts.Wait {
-		return rFromService.Wait(service)
+		err := rFromService.Wait(service)
+		if err != nil {
+			return err
+		}
 	}
 
 	if opts.Clean {
-		return rFromService.Delete(service)
+		err := rFromService.Delete()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Raised under ticket [#1817](https://github.com/rancher/rancher/issues/1817). 
When running through an upgrade, the containers for the old service are removed, however the service is left in-place, this is by design but some users of this function (ourselves being one) would like the process to be fully automated.

We've been using rancher for a few months now but this is our first pull request, be gentle! :)

This has been tested locally in a linux environment and worked as expected.

Update: We've explicitly implied usage of the wait function already present. This is so that the deletion of the old service always only occurs after the upgrade process is completed. Also fixed the gofmt compliance.