### PR TITLE
Add support for user defined metadata

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/rancher/rancher-compose",
-	"GoVersion": "go1.4.1",
+	"GoVersion": "go1.5",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -292,13 +292,13 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher/client",
-			"Comment": "v0.1.0-69-g179d8a4",
-			"Rev": "179d8a42a477d2de0a4e7a4f5a99df67d80ed1d8"
+			"Comment": "v0.1.0-71-g0b17bcf",
+			"Rev": "0b17bcf6c29e2cdafafaa33301c12589a10ff2eb"
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher/hostaccess",
-			"Comment": "v0.1.0-69-g179d8a4",
-			"Rev": "179d8a42a477d2de0a4e7a4f5a99df67d80ed1d8"
+			"Comment": "v0.1.0-71-g0b17bcf",
+			"Rev": "0b17bcf6c29e2cdafafaa33301c12589a10ff2eb"
 		},
 		{
 			"ImportPath": "github.com/samalba/dockerclient",

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container.go
@@ -33,6 +33,8 @@ type Container struct {
 
 	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
 
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
 	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
 
 	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_dns_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_dns_service.go
@@ -19,6 +19,8 @@ type DnsService struct {
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service.go
@@ -25,6 +25,8 @@ type ExternalService struct {
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_launch_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_launch_config.go
@@ -33,6 +33,8 @@ type LaunchConfig struct {
 
 	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
 
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
 	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
 
 	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
@@ -27,6 +27,8 @@ type LoadBalancerService struct {
 
 	LoadBalancerConfig *LoadBalancerConfig `json:"loadBalancerConfig,omitempty" yaml:"load_balancer_config,omitempty"`
 
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
@@ -33,6 +33,8 @@ type SecondaryLaunchConfig struct {
 
 	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
 
+	DataVolumeMounts map[string]interface{} `json:"dataVolumeMounts,omitempty" yaml:"data_volume_mounts,omitempty"`
+
 	DataVolumes []string `json:"dataVolumes,omitempty" yaml:"data_volumes,omitempty"`
 
 	DataVolumesFrom []string `json:"dataVolumesFrom,omitempty" yaml:"data_volumes_from,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service.go
@@ -23,6 +23,8 @@ type Service struct {
 
 	LaunchConfig LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
 
+	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_volume.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_volume.go
@@ -15,6 +15,10 @@ type Volume struct {
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
+	Driver string `json:"driver,omitempty" yaml:"driver,omitempty"`
+
+	DriverOpts map[string]interface{} `json:"driverOpts,omitempty" yaml:"driver_opts,omitempty"`
+
 	ImageId string `json:"imageId,omitempty" yaml:"image_id,omitempty"`
 
 	InstanceId string `json:"instanceId,omitempty" yaml:"instance_id,omitempty"`
@@ -57,8 +61,6 @@ type VolumeOperations interface {
 	Update(existing *Volume, updates interface{}) (*Volume, error)
 	ById(id string) (*Volume, error)
 	Delete(container *Volume) error
-
-	ActionActivate(*Volume) (*Volume, error)
 
 	ActionAllocate(*Volume) (*Volume, error)
 
@@ -109,15 +111,6 @@ func (c *VolumeClient) ById(id string) (*Volume, error) {
 
 func (c *VolumeClient) Delete(container *Volume) error {
 	return c.rancherClient.doResourceDelete(VOLUME_TYPE, &container.Resource)
-}
-
-func (c *VolumeClient) ActionActivate(resource *Volume) (*Volume, error) {
-
-	resp := &Volume{}
-
-	err := c.rancherClient.doAction(VOLUME_TYPE, "activate", &resource.Resource, nil, resp)
-
-	return resp, err
 }
 
 func (c *VolumeClient) ActionAllocate(resource *Volume) (*Volume, error) {

--- a/rancher/context.go
+++ b/rancher/context.go
@@ -43,6 +43,7 @@ type RancherConfig struct {
 	HealthCheck        *rancherClient.InstanceHealthCheck `yaml:"health_check,omitempty"`
 	DefaultCert        string                             `yaml:"default_cert,omitempty"`
 	Certs              []string                           `yaml:"certs,omitempty"`
+	Metadata           map[string]interface{}             `yaml:"metadata,omitempty"`
 }
 
 func (c *Context) readRancherConfig() error {

--- a/rancher/service.go
+++ b/rancher/service.go
@@ -338,11 +338,19 @@ func (r *RancherService) createNormalService() (*rancherClient.Service, error) {
 
 	return r.context.Client.Service.Create(&rancherClient.Service{
 		Name:                   r.name,
+		Metadata:               r.getMetadata(),
 		LaunchConfig:           launchConfig,
 		SecondaryLaunchConfigs: secondaryLaunchConfigs,
 		Scale:         int64(r.getConfiguredScale()),
 		EnvironmentId: r.context.Environment.Id,
 	})
+}
+
+func (r *RancherService) getMetadata() map[string]interface{} {
+	if config, ok := r.context.RancherConfig[r.name]; ok {
+		return config.Metadata
+	}
+	return nil
 }
 
 func (r *RancherService) getHealthCheck() *rancherClient.InstanceHealthCheck {

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -19,3 +19,7 @@ fi
 if [ ! $(command -v zip) ]; then
     apt-get install -y --no-install-recommends zip xz-utils
 fi
+
+if [ ! $(command -v rsync) ]; then
+    apt-get install -y --no-install-recommends rsync
+fi

--- a/scripts/run-cattle
+++ b/scripts/run-cattle
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL=https://github.com/rancher/cattle/releases/download/v0.93.0/cattle.jar
+URL=https://github.com/rancher/cattle/releases/download/v0.96.0/cattle.jar
 
 cd $(dirname $0)/..
 

--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ setup_root()
 {
     if [ -d /scratch ]; then
         SCRATCH_TEMP=$(mktemp -d /scratch/cattle.XXXXX)
-        rsync --exclude '*.pyc' -a tests $SCRATCH_TEMP
+        rsync --exclude '*.pyc' -a ./ $SCRATCH_TEMP
         pushd $SCRATCH_TEMP
     fi
 }

--- a/tests/integration/cattletest/core/assets/metadata/rancher-compose.yml
+++ b/tests/integration/cattletest/core/assets/metadata/rancher-compose.yml
@@ -1,0 +1,5 @@
+web:
+  metadata:
+    key1:
+      - one
+      - two

--- a/tests/integration/cattletest/core/assets/metadata/test.yml
+++ b/tests/integration/cattletest/core/assets/metadata/test.yml
@@ -1,0 +1,2 @@
+web:
+  image: nginx


### PR DESCRIPTION
This PR adds support for user supplied metadata, that will be made
available to containers via the rancher-metadata api.

Minor changes were made to the test and bootstrap script to make the
/scratch code path work.