### PR TITLE
Building old versions errors

### DIFF
--- a/scripts/common_functions
+++ b/scripts/common_functions
@@ -11,7 +11,7 @@ set_project_vars()
 
 get_version()
 {
-    VERSION=$(git tag -l --contains HEAD)
+    VERSION=$(git tag -l --contains HEAD | head -n 1)
     if [ -z "$VERSION" ]; then
         VERSION=$(git rev-parse --short HEAD)
     fi


### PR DESCRIPTION
Hi,

I tried to build rancher-compose but when building last stable `VERSION=v0.5.0 v0.5.0-rc2 v0.5.1 v0.5.2-rc1 v0.5.2-rc2` made `6l` vomit help.
Hence this pull.

```
export GOPATH=/source/Godeps/_workspace:/source/gopath
VERSION=v0.5.0 v0.5.0-rc2 v0.5.1 v0.5.2-rc1 v0.5.2-rc2
# _/source
usage: 6l [options] main.6
...
```