### PR TITLE
Dependent services of type link should be optional

### DIFF
--- a/rancher/sidekick.go
+++ b/rancher/sidekick.go
@@ -41,7 +41,14 @@ func (s *Sidekick) Config() *project.ServiceConfig {
 }
 
 func (s *Sidekick) DependentServices() []project.ServiceRelationship {
-	return project.DefaultDependentServices(s.context.Project, s)
+	dependentServices := project.DefaultDependentServices(s.context.Project, s)
+	for i, dependentService := range dependentServices {
+		if dependentService.Type == project.RelTypeLink {
+			dependentServices[i].Optional = true
+		}
+	}
+
+	return dependentServices
 }
 
 func (s *Sidekick) Log() error {

--- a/tests/integration/cattletest/core/assets/cyclic-link-dependency/docker-compose.yml
+++ b/tests/integration/cattletest/core/assets/cyclic-link-dependency/docker-compose.yml
@@ -1,0 +1,13 @@
+service1:
+  image: ubuntu:14.04
+  volumes_from:
+    - data
+data:
+  image: ubuntu:14.04
+service2:
+  image: ubuntu:14.04
+  links: 
+    - service1
+    - data
+  labels:  
+    io.rancher.sidekicks: service1, data

--- a/tests/integration/cattletest/core/test_compose.py
+++ b/tests/integration/cattletest/core/test_compose.py
@@ -1865,3 +1865,9 @@ vm:
     assert vm.launchConfig.disks[0] == {'name': 'foo', 'size': '1g',
                                         'opts': {'foo': 'bar'}}
     assert vm.launchConfig.disks[1] == {'name': 'foo2', 'size': '2g'}
+
+
+def test_cyclic_link_dependency(client, compose):
+    # cyclic link dependencies shouldn't error or hang
+    create_project(compose, file='assets/cyclic-link-dependency/'
+                                 'docker-compose.yml')


### PR DESCRIPTION
This is half of the fix for rancher/rancher#2636. When adding both links and the sidekick label, a circular dependency is created. For these cases the dependency can be safely ignored, and so the `Optional` attribute should be set.

The other half is that the error created by the circular dependency is not handled, which causes rancher-compose to hang for these types of files. This fix should be in libcompose and I will open a PR there soon.

rancher/rancher#2636
rancher/rancher#3424