### PR TITLE
Check message type after checking for error

### DIFF
--- a/rancher/service.go
+++ b/rancher/service.go
@@ -551,9 +551,6 @@ func (r *RancherService) pipeLogs(container *rancherClient.Container, conn *webs
 
 	for {
 		messageType, bytes, err := conn.ReadMessage()
-		if messageType != websocket.TextMessage {
-			continue
-		}
 
 		if err == io.EOF {
 			return
@@ -562,7 +559,7 @@ func (r *RancherService) pipeLogs(container *rancherClient.Container, conn *webs
 			return
 		}
 
-		if len(bytes) <= 3 {
+		if messageType != websocket.TextMessage || len(bytes) <= 3 {
 			continue
 		}
 


### PR DESCRIPTION
Previously the message type was checked before errors. When an `io.EOF` error was received the `continue` statement was getting hit since `messageType != websocket.TextMessage` when there is an error. rancher/rancher#3348