### PR TITLE
Explicitly set Content-type for S3 upload to `application/tar`

### DIFF
--- a/rancher/s3_uploader.go
+++ b/rancher/s3_uploader.go
@@ -52,9 +52,10 @@ func (s *S3Uploader) Upload(p *project.Project, name string, reader io.ReadSeeke
 
 func putFile(svc *s3.S3, bucket, object string, reader io.ReadSeeker) error {
 	_, err := svc.PutObject(&s3.PutObjectInput{
-		Bucket: &bucket,
-		Key:    &object,
-		Body:   reader,
+		Bucket:      &bucket,
+		Key:         &object,
+		Body:        reader,
+		ContentType: aws.String("application/tar"),
 	})
 
 	return err


### PR DESCRIPTION
Explicitly setting the Content-type seemed to fix the bug where using upgrade with build would fail as noted in https://github.com/rancher/rancher/issues/2666.

It seems that S3 will default to a Content-type of `binary/octet-stream`.

I've hardcoded the Content-type as `application/tar` since `docker.CreateTar()` in `libcompose` creates an uncompressed tar - but Docker build regex will also support `application/octet-stream`.

Thoughts?