### PR TITLE
Send empty log options instead of nil

### DIFF
--- a/rancher/configs.go
+++ b/rancher/configs.go
@@ -98,6 +98,10 @@ func createLaunchConfig(r *RancherService, name string, serviceConfig *config.Se
 		result.Kind = "virtualMachine"
 	}
 
+	if result.LogConfig.Config == nil {
+		result.LogConfig.Config = map[string]interface{}{}
+	}
+
 	return result, err
 }
 


### PR DESCRIPTION
Depends on rancher/go-rancher#101

A `nil` value for log options will cause Cattle to set the log driver to the default `json-driver`. If an empty JSON object is sent instead, the driver is set properly.

rancher/rancher#4773