### PR TITLE
Disable relative paths for volumes and give a warning

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -35,7 +35,7 @@ func (p *ProjectFactory) Create(c *cli.Context) (*project.Project, error) {
 
 	context := &rancher.Context{
 		Context: project.Context{
-			ResourceLookup:    &lookup.FileConfigLookup{},
+			ResourceLookup:    &rLookup.FileConfigLookup{},
 			EnvironmentLookup: envLookup,
 			LoggerFactory:     logger.NewColorLoggerFactory(),
 		},

--- a/executor/handlers/project.go
+++ b/executor/handlers/project.go
@@ -26,6 +26,7 @@ func constructProjectUpgrade(logger *logrus.Entry, env *client.Environment, upgr
 			ComposeBytes: [][]byte{
 				[]byte(upgradeOpts.DockerCompose),
 			},
+			ResourceLookup: &lookup.FileConfigLookup{},
 			EnvironmentLookup: &lookup.MapEnvLookup{
 				Env: variables,
 			},
@@ -53,6 +54,7 @@ func constructProject(logger *logrus.Entry, env *client.Environment, url, access
 			ComposeBytes: [][]byte{
 				[]byte(env.DockerCompose),
 			},
+			ResourceLookup: &lookup.FileConfigLookup{},
 			EnvironmentLookup: &lookup.MapEnvLookup{
 				Env: env.Environment,
 			},

--- a/lookup/file.go
+++ b/lookup/file.go
@@ -1,0 +1,22 @@
+package lookup
+
+import (
+	"path/filepath"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libcompose/lookup"
+)
+
+type FileConfigLookup struct {
+	lookup.FileConfigLookup
+}
+
+// Give a warning rather than resolve relative paths
+func (f *FileConfigLookup) ResolvePath(path, inFile string) string {
+	vs := strings.SplitN(path, ":", 2)
+	if len(vs) == 2 && !filepath.IsAbs(vs[0]) {
+		log.Warnf("Rancher Compose will not resolve relative path %s", vs[0])
+	}
+	return path
+}


### PR DESCRIPTION
Resolving relative paths for volumes doesn't provide much value when deploying to different hosts. If a Compose file contains a relative path, throw a warning. Throwing an error and exiting might also be a reasonable behavior here.

rancher/rancher#4947