### PR TITLE
Use yaml.Stringorint for rancher-compose.yml integer fields

### DIFF
--- a/rancher/configs.go
+++ b/rancher/configs.go
@@ -86,9 +86,9 @@ func createLaunchConfig(r *RancherService, name string, serviceConfig *config.Se
 	}
 
 	result.Kind = rancherConfig.Type
-	result.Vcpu = rancherConfig.Vcpu
+	result.Vcpu = int64(rancherConfig.Vcpu)
 	result.Userdata = rancherConfig.Userdata
-	result.MemoryMb = rancherConfig.Memory
+	result.MemoryMb = int64(rancherConfig.Memory)
 	result.Disks = []interface{}{}
 	for _, i := range rancherConfig.Disks {
 		result.Disks = append(result.Disks, i)

--- a/rancher/context.go
+++ b/rancher/context.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/utils"
+	composeYaml "github.com/docker/libcompose/yaml"
 	rancherClient "github.com/rancher/go-rancher/client"
 	rUtils "github.com/rancher/rancher-compose/utils"
 	rVersion "github.com/rancher/rancher-compose/version"
@@ -52,13 +53,13 @@ type Context struct {
 
 type RancherConfig struct {
 	// VirtualMachine fields
-	Vcpu     int64                              `yaml:"vcpu,omitempty"`
+	Vcpu     composeYaml.StringorInt            `yaml:"vcpu,omitempty"`
 	Userdata string                             `yaml:"userdata,omitempty"`
-	Memory   int64                              `yaml:"memory,omitempty"`
+	Memory   composeYaml.StringorInt            `yaml:"memory,omitempty"`
 	Disks    []rancherClient.VirtualMachineDisk `yaml:"disks,omitempty"`
 
 	Type               string                                 `yaml:"type,omitempty"`
-	Scale              int                                    `yaml:"scale,omitempty"`
+	Scale              composeYaml.StringorInt                `yaml:"scale,omitempty"`
 	RetainIp           bool                                   `yaml:"retain_ip,omitempty"`
 	LoadBalancerConfig *rancherClient.LoadBalancerConfig      `yaml:"load_balancer_config,omitempty"`
 	ExternalIps        []string                               `yaml:"external_ips,omitempty"`

--- a/rancher/service.go
+++ b/rancher/service.go
@@ -276,7 +276,7 @@ func (r *RancherService) getConfiguredScale() int {
 	scale := 1
 	if config, ok := r.context.RancherConfig[r.name]; ok {
 		if config.Scale > 0 {
-			scale = config.Scale
+			scale = int(config.Scale)
 		}
 	}
 

--- a/scripts/config_schema_v1.json
+++ b/scripts/config_schema_v1.json
@@ -111,7 +111,7 @@
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "retain_ip": {"type": "boolean"},
-        "scale": {"type": "number"},
+        "scale": {"type": ["number", "string"]},
         "scale_policy": {"type": "object"},
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "shm_size": {"type": ["number", "string"]},

--- a/vendor/github.com/docker/libcompose/config/schema.go
+++ b/vendor/github.com/docker/libcompose/config/schema.go
@@ -113,7 +113,7 @@ var schemaV1 = `{
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "retain_ip": {"type": "boolean"},
-        "scale": {"type": "number"},
+        "scale": {"type": ["number", "string"]},
         "scale_policy": {"type": "object"},
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "shm_size": {"type": ["number", "string"]},


### PR DESCRIPTION
Also updates the `scale` schema to allow strings.

rancher/rancher#5705