### PR TITLE
Try converting strings to integers for go-rancher fields

### DIFF
--- a/preprocess/project.go
+++ b/preprocess/project.go
@@ -2,6 +2,7 @@ package preprocess
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/docker/libcompose/config"
 )
@@ -50,6 +51,59 @@ func Preprocess(item interface{}, replaceTypes bool) interface{} {
 		if replaceTypes {
 			return fmt.Sprint(item)
 		}
+		return item
+	}
+}
+
+func TryConvertStringsToInts(serviceMap config.RawServiceMap) (config.RawServiceMap, error) {
+	newServiceMap := make(config.RawServiceMap)
+
+	for k, v := range serviceMap {
+		newServiceMap[k] = make(config.RawService)
+
+		for k2, v2 := range v {
+			if k2 == "disks" || k2 == "load_balancer_config" || k2 == "health_check" || k2 == "scale_policy" || k2 == "upgrade_strategy" || k2 == "service_schemas" {
+				newServiceMap[k][k2] = tryConvertStringsToInts(v2, true)
+			} else {
+				newServiceMap[k][k2] = tryConvertStringsToInts(v2, false)
+			}
+
+		}
+	}
+
+	return newServiceMap, nil
+}
+
+func tryConvertStringsToInts(item interface{}, replaceTypes bool) interface{} {
+	switch typedDatas := item.(type) {
+
+	case map[interface{}]interface{}:
+		newMap := make(map[interface{}]interface{})
+
+		for key, value := range typedDatas {
+			newMap[key] = tryConvertStringsToInts(value, replaceTypes)
+		}
+		return newMap
+
+	case []interface{}:
+		// newArray := make([]interface{}, 0) will cause golint to complain
+		var newArray []interface{}
+		newArray = make([]interface{}, 0)
+
+		for _, value := range typedDatas {
+			newArray = append(newArray, tryConvertStringsToInts(value, replaceTypes))
+		}
+		return newArray
+
+	case string:
+		lineAsInteger, err := strconv.Atoi(typedDatas)
+
+		if replaceTypes && err == nil {
+			return lineAsInteger
+		}
+
+		return item
+	default:
 		return item
 	}
 }

--- a/rancher/context.go
+++ b/rancher/context.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/libcompose/utils"
 	composeYaml "github.com/docker/libcompose/yaml"
 	rancherClient "github.com/rancher/go-rancher/client"
+	"github.com/rancher/rancher-compose/preprocess"
 	rUtils "github.com/rancher/rancher-compose/utils"
 	rVersion "github.com/rancher/rancher-compose/version"
 
@@ -140,6 +141,10 @@ func (c *Context) unmarshalBytes(composeBytes, bytes []byte) error {
 
 func (c *Context) fillInRancherConfig(rawServiceMap config.RawServiceMap) error {
 	if err := config.Interpolate(c.EnvironmentLookup, &rawServiceMap); err != nil {
+		return err
+	}
+	rawServiceMap, err := preprocess.TryConvertStringsToInts(rawServiceMap)
+	if err != nil {
 		return err
 	}
 	if err := utils.Convert(rawServiceMap, &c.RancherConfig); err != nil {


### PR DESCRIPTION
Types that come from go-rancher cannot use the `StringorInt` field to handle strings in integer fields. This PR preprocesses the values for those particular keys and tries to convert string values to integers.

A little bit a duplicated code is introduced in the preprocess package, but this should be pretty easy to refactor later.

rancher/rancher#5755