### PR TITLE
Bindings

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -49,6 +49,7 @@ func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 		PullCached:         c.Bool("cached"),
 		Uploader:           &rancher.S3Uploader{},
 		Args:               c.Args(),
+		BindingsFile:       c.GlobalString("bindings-file"),
 	}
 	qLookup.Context = context
 

--- a/executor/handlers/project.go
+++ b/executor/handlers/project.go
@@ -36,6 +36,7 @@ func constructProjectUpgrade(logger *logrus.Entry, stack *client.Stack, upgradeO
 		SecretKey:           secretKey,
 		RancherComposeBytes: []byte(upgradeOpts.RancherCompose),
 		Upgrade:             true,
+		Binding:             stack.Binding,
 	}
 
 	p, err := rancher.NewProject(&context)
@@ -63,6 +64,7 @@ func constructProject(logger *logrus.Entry, stack *client.Stack, url, accessKey,
 		AccessKey:           accessKey,
 		SecretKey:           secretKey,
 		RancherComposeBytes: []byte(stack.RancherCompose),
+		Binding:             stack.Binding,
 	}
 
 	p, err := rancher.NewProject(&context)

--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ func cliMain() {
 			Name:  "env-file,e",
 			Usage: "Specify a file from which to read environment variables",
 		},
+		cli.StringFlag{
+			Name:  "bindings-file,b",
+			Usage: "Specify a file from which to read bindings",
+		},
 	)
 	app.Commands = []cli.Command{
 		rancherApp.CreateCommand(factory),

--- a/rancher/context.go
+++ b/rancher/context.go
@@ -33,6 +33,9 @@ type Context struct {
 	RancherConfig       map[string]RancherConfig
 	RancherComposeFile  string
 	RancherComposeBytes []byte
+	BindingsFile        string
+	Binding             *client.Binding
+	BindingsBytes       []byte
 	Url                 string
 	AccessKey           string
 	SecretKey           string
@@ -73,6 +76,15 @@ type RancherConfig struct {
 	ScalePolicy        *client.ScalePolicy             `yaml:"scale_policy,omitempty"`
 	ServiceSchemas     map[string]client.Schema        `yaml:"service_schemas,omitempty"`
 	UpgradeStrategy    client.InServiceUpgradeStrategy `yaml:"upgrade_strategy,omitempty"`
+}
+
+type BindingProperty struct {
+	Services map[string]Service `json:"services"`
+}
+
+type Service struct {
+	Labels map[string]interface{} `json:"labels"`
+	Ports  []interface{}          `json:"ports"`
 }
 
 func ResolveRancherCompose(composeFile, rancherComposeFile string) (string, error) {
@@ -144,6 +156,7 @@ func (c *Context) fillInRancherConfig(rawServiceMap config.RawServiceMap) error 
 	if err := config.Interpolate(c.EnvironmentLookup, &rawServiceMap); err != nil {
 		return err
 	}
+
 	rawServiceMap, err := preprocess.TryConvertStringsToInts(rawServiceMap)
 	if err != nil {
 		return err

--- a/rancher/project.go
+++ b/rancher/project.go
@@ -1,10 +1,12 @@
 package rancher
 
 import (
+	"encoding/json"
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
 	"github.com/rancher/rancher-compose/preprocess"
+	"io/ioutil"
 )
 
 func NewProject(context *Context) (*project.Project, error) {
@@ -12,10 +14,29 @@ func NewProject(context *Context) (*project.Project, error) {
 		Context: context,
 	}
 
+	if context.Binding != nil {
+		bindingBytes, err := json.Marshal(context.Binding)
+		if err != nil {
+			return nil, err
+		}
+		context.BindingsBytes = bindingBytes
+	}
+
+	if context.BindingsBytes == nil {
+		if context.BindingsFile != "" {
+			bindingsContent, err := ioutil.ReadFile(context.BindingsFile)
+			if err != nil {
+				return nil, err
+			}
+			context.BindingsBytes = bindingsContent
+		}
+	}
+
+	preProcessServiceMap := preprocess.PreprocessServiceMap(context.BindingsBytes)
 	p := project.NewProject(&context.Context, nil, &config.ParseOptions{
 		Interpolate: true,
 		Validate:    true,
-		Preprocess:  preprocess.PreprocessServiceMap,
+		Preprocess:  preProcessServiceMap,
 	})
 
 	err := p.Parse()

--- a/tests/integration/cattletest/core/assets/bindings.json
+++ b/tests/integration/cattletest/core/assets/bindings.json
@@ -1,0 +1,10 @@
+{
+	"services": {
+		"prometheus": {
+			"labels": {
+				"labels_prom_binding": "value_prom_binding"
+			},
+			"ports": ["8081"]
+		}
+	}
+}


### PR DESCRIPTION
On providing a `bindings.json` file through command line, the `scale`, `ports` and `labels` fields for the services are replaced by the ones provided in bindings.json.

The file is provided as an argument: `--bindings-file bindings.json`