### PR TITLE
Make service optional in rancher-compose.yml for legacy load balancers

### DIFF
--- a/rancher/lb_service.go
+++ b/rancher/lb_service.go
@@ -11,16 +11,22 @@ import (
 )
 
 func populateLbFields(r *RancherService, launchConfig *client.LaunchConfig, service *CompositeService) error {
+	serviceType := FindServiceType(r)
+
 	config, ok := r.context.RancherConfig[r.name]
 	if !ok {
-		return nil
+		if serviceType == LegacyLbServiceType {
+			r.context.RancherConfig[r.name] = RancherConfig{}
+			config = r.context.RancherConfig[r.name]
+		} else {
+			return nil
+		}
 	}
 
 	// Write back to the ports passed in because the Docker parsing logic changes then
 	launchConfig.Ports = r.serviceConfig.Ports
 	launchConfig.Expose = r.serviceConfig.Expose
 
-	serviceType := FindServiceType(r)
 	if serviceType == LegacyLbServiceType {
 		existingHAProxyConfig := ""
 		var legacyStickinessPolicy *legacyClient.LoadBalancerCookieStickinessPolicy


### PR DESCRIPTION
If there is a legacy load balancer present in `docker-compose.yml` but not `rancher-compose.yml` then an error will currently be thrown. The load balancer service shouldn't actually be required in `rancher-compose.yml`, so make this optional.

rancher/rancher#6818