### PR TITLE
Add ability to select S3 bucket for builds

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -47,7 +47,9 @@ func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 		AccessKey:          c.GlobalString("access-key"),
 		SecretKey:          c.GlobalString("secret-key"),
 		PullCached:         c.Bool("cached"),
-		Uploader:           &rancher.S3Uploader{},
+		Uploader: &rancher.S3Uploader{
+			Bucket: c.String("bucket"),
+		},
 		Args:               c.Args(),
 		BindingsFile:       c.GlobalString("bindings-file"),
 	}
@@ -102,6 +104,10 @@ func UpgradeCommand(factory app.ProjectFactory) cli.Command {
 			cli.BoolFlag{
 				Name:  "cleanup, c",
 				Usage: "Remove the original service definition once upgraded, implies --wait",
+			},
+			cli.StringFlag{
+				Name:  "bucket",
+				Usage: "Specify S3 bucket to upload builds to",
 			},
 		},
 	}
@@ -166,6 +172,10 @@ func UpCommand(factory app.ProjectFactory) cli.Command {
 				Name:  "interval",
 				Usage: "Update interval in milliseconds",
 				Value: 1000,
+			},
+			cli.StringFlag{
+				Name:  "bucket",
+				Usage: "Specify S3 bucket to upload builds to",
 			},
 		},
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -50,8 +50,8 @@ func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 		Uploader: &rancher.S3Uploader{
 			Bucket: c.String("bucket"),
 		},
-		Args:               c.Args(),
-		BindingsFile:       c.GlobalString("bindings-file"),
+		Args:         c.Args(),
+		BindingsFile: c.GlobalString("bindings-file"),
 	}
 	qLookup.Context = context
 

--- a/rancher/s3_uploader.go
+++ b/rancher/s3_uploader.go
@@ -16,6 +16,7 @@ import (
 )
 
 type S3Uploader struct {
+	Bucket string
 }
 
 func (s *S3Uploader) Name() string {
@@ -23,7 +24,12 @@ func (s *S3Uploader) Name() string {
 }
 
 func (s *S3Uploader) Upload(p *project.Project, name string, reader io.ReadSeeker, hash string) (string, string, error) {
-	bucketName := fmt.Sprintf("%s-%s", p.Name, someHash())
+	bucketName := s.Bucket
+
+	if bucketName == "" {
+		bucketName = fmt.Sprintf("%s-%s", p.Name, someHash())
+	}
+
 	objectKey := fmt.Sprintf("%s-%s", name, hash[:12])
 
 	config := aws.DefaultConfig.Copy()


### PR DESCRIPTION
Currently, `rancher-compose` creates one new S3 bucket whenever the `up` or `upgrade` command is called and an image has to be built.

This is a problem, because the amount of buckets is limited. While the limit can be raised, it doesn't solve the problem once for all. (see https://github.com/rancher/rancher/issues/3989)

```
time="2017-02-10T16:28:21Z" level=error msg="Failed to calculate hash for service a-service: TooManyBuckets: You have attempted to create more buckets than allowed\n\tstatus code: 400, request id: []" 
```

This is why this pr adds the `--bucket` argument to the `up` and `upgrade` commands. It allows users to specify which bucket to write the build contexts to. That way teams can use one single S3 bucket for builds, without polluting their S3 space.