### PR TITLE
Enabled sysctls option on 2.0 schema

### DIFF
--- a/scripts/config_schema_v2.0.json
+++ b/scripts/config_schema_v2.0.json
@@ -186,6 +186,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_signal": {"type": "string"},
         "storage_driver": {"type": "object"},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "type": {"type": "string"},

--- a/vendor/github.com/docker/libcompose/config/schema.go
+++ b/vendor/github.com/docker/libcompose/config/schema.go
@@ -336,6 +336,7 @@ var servicesSchemaDataV2 = `{
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
         "labels": {"$ref": "#/definitions/list_or_dict"},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
         "lb_config": {"type": "object"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "load_balancer_config": {"type": "object"},

--- a/vendor/github.com/docker/libcompose/config/types.go
+++ b/vendor/github.com/docker/libcompose/config/types.go
@@ -121,6 +121,7 @@ type ServiceConfig struct {
 	Extends           yaml.MaporEqualSlice `yaml:"extends,omitempty"`
 	ExternalLinks     []string             `yaml:"external_links,omitempty"`
 	ExtraHosts        []string             `yaml:"extra_hosts,omitempty"`
+	Sysctls           yaml.SliceorMap      `yaml:"sysctls,omitempty"`
 	GroupAdd          []string             `yaml:"group_add,omitempty"`
 	Image             string               `yaml:"image,omitempty"`
 	Isolation         string               `yaml:"isolation,omitempty"`

--- a/vendor/github.com/docker/libcompose/docker/service/convert.go
+++ b/vendor/github.com/docker/libcompose/docker/service/convert.go
@@ -253,6 +253,7 @@ func Convert(c *config.ServiceConfig, ctx project.Context) (*container.Config, *
 		CapDrop:     strslice.StrSlice(utils.CopySlice(c.CapDrop)),
 		GroupAdd:    c.GroupAdd,
 		ExtraHosts:  utils.CopySlice(c.ExtraHosts),
+		Sysctls:     c.Sysctls,
 		Privileged:  c.Privileged,
 		Binds:       Filter(vols, isBind),
 		DNS:         utils.CopySlice(c.DNS),


### PR DESCRIPTION
**- Whats is it good for**

Rancher supports from 1.6 on setting the `sysctls` configuration when a
`docker-compose.yml` is provided while creating a stack through the UI.
Unfortunately `rancher-compose` is not able to do the same. This results in
errors like this:

```bash
time="2017-10-08T16:32:51Z" level=error msg="Could not parse config for project test : Unsupported config option for test service: 'sysctls'"
```

See the related issues/code:
* https://github.com/rancher/rancher/issues/8243
* https://github.com/rancher/rancher-compose-executor/blob/master/parser/schema.go#L145

**- What I did**

I just added the `sysctls` option to the `2.0` schema. Thats it.

**- How I tested it**

The following example disables IPv6. Put it in `docker-compose.yml` and run
`rancher-compose up`.

```yaml
version: '2'
services:
  test:
    image: nginx
    sysctls:
       # Disable IPv6 due to issues with Amazon SES SMTP endpoint
       net.ipv6.conf.all.disable_ipv6: '1'
       net.ipv6.conf.default.disable_ipv6: '1'
       net.ipv6.conf.lo.disable_ipv6: '1'
```

The command outputs this:

```bash
INFO[0000] [0/1] [test]: Creating
INFO[0006] [0/1] [test]: Created
INFO[0006] [0/1] [test]: Starting
INFO[0007] Checking for nginx on coordinator...
INFO[0007] Checking for nginx on shp...
INFO[0018] Finished nginx on shp
INFO[0019] Finished nginx on coordinator
INFO[0019] Finished pulling nginx
INFO[0019] Updating test
INFO[0032] Upgrading test
INFO[0050] [1/1] [test]: Started
```

**- Docker image with patched rancher-compose**

I just forked [monostream/rancher-compose](https://hub.docker.com/r/monostream/rancher-compose/) and added the [patched version of rancher-compose](https://hub.docker.com/r/jack12816/docker-rancher-compose/).
So if someone is interested in a temporary workaround for ci.  

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/31319258-3c4b2440-ac60-11e7-9cea-0c3420d51e0a.jpeg)
