### PR TITLE
Fixed golint issue & fixed python-setuptools issue

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,10 @@
-FROM golang:1.7.3
+FROM golang:1.11.5
 RUN go get github.com/rancher/trash
 RUN go get github.com/golang/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends default-jre python-pip zip xz-utils rsync
+    apt-get install -y --no-install-recommends default-jre python-pip zip xz-utils rsync python-setuptools
 RUN pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4
 ENV PATH /go/bin:$PATH
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher-compose


### PR DESCRIPTION
I was unable to 'make' on Arch Linux (both through pacaur and manually.
I determined the issue to be a golint issue, then I bumped into a second issue where python wanted python-setuptools installed. That fixed the compilation issue and I rancher-compose installed properly.

First Error:
```
make
Downloading dapper
./.dapper.tmp version v0.3.4
./.dapper ci
Sending build context to Docker daemon  15.71MB
Step 1/15 : FROM golang:1.7.3
 ---> ef15416724f6
Step 2/15 : RUN go get github.com/rancher/trash
 ---> Using cache
 ---> 797691318d2c
Step 3/15 : RUN go get github.com/golang/lint/golint
 ---> Running in 288e1c28248a
# golang.org/x/tools/go/internal/gcimporter
src/golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
The command '/bin/sh -c go get github.com/golang/lint/golint' returned a non-zero code: 2
FATA[0012] exit status 2
make: *** [Makefile:11: ci] Error 1
```
Second Error:
```
make
./.dapper ci
Sending build context to Docker daemon  15.71MB
Step 1/15 : FROM golang:1.11.5
1.11.5: Pulling from library/golang
Digest: sha256:702c5b891715bdce8d75f70232de5b9858a0c655130ebbbf8314bf071473208d
Status: Downloaded newer image for golang:1.11.5
 ---> 5049ec6e3141
Step 2/15 : RUN go get github.com/rancher/trash
 ---> Using cache
 ---> 6266021afb49
Step 3/15 : RUN go get github.com/golang/lint/golint
 ---> Using cache
 ---> 212872e76231
Step 4/15 : RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker &&     chmod +x /usr/bin/docker
 ---> Using cache
 ---> e68c2aed2d82
Step 5/15 : RUN apt-get update &&     apt-get install -y --no-install-recommends default-jre python-pip zip xz-utils rsync
 ---> Using cache
 ---> 3a06bc064fda
Step 6/15 : RUN pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4
 ---> Running in 773aef2c556c
Collecting pip==6.0.3
  Downloading https://files.pythonhosted.org/packages/73/cb/3eebf42003791df29219a3dfa1874572aa16114b44c9b1b0ac66bf96e8c0/pip-6.0.3-py2.py3-none-any.whl (1.3MB)
Collecting tox==1.8.1
  Downloading https://files.pythonhosted.org/packages/bb/e3/3a9f07db8a0c2353dd4f20bbe375ccdec3a7c0f62ec38974948c4d24a145/tox-1.8.1.tar.gz (90kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-p0SQj_/tox/
The command '/bin/sh -c pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4' returned a non-zero code: 1
```